### PR TITLE
Fix installation for virtual environment users

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,21 @@
 - easy [gst-python](https://github.com/GStreamer/gst-python) installation
 
 ### Install
+
+__FOR ANY VIRTUAL ENVIRONMENT USERS, MAKE SURE YOU COMPILED PYTHON WITH
+`--enable-shared`(ESPECTIALLY FOR PYENV USERS) OR GST-PYTHON WON'T BE PROPERLY
+INSTALLED.__
+
 #### Install OS packages
 - [How to install Gstreamer on Ubuntu](http://lifestyletransfer.com/how-to-install-gstreamer-on-ubuntu/)
 - [How to install Gstreamer Python Bindings](http://lifestyletransfer.com/how-to-install-gstreamer-python-bindings/)
 
 #### in-place
+
+You need to install meson and ninja first. Usually just search meson and
+install it using your package manager and ninja will be automatically
+installed.
+
 ```bash
 python3 -m venv venv
 
@@ -23,6 +33,15 @@ pip install --upgrade --requirement requirements.txt
 ```
 
 #### pip-package
+
+You need to install meson and ninja first. Usually just search meson and
+install it using your package manager and ninja will be automatically
+installed.
+
+Note this package will not raise an exception for any error that happends. In
+the case of any error occurs, you might have a broken installation(e.g.
+gst-python not properly installed).
+
 ```bash
 
 pip install git+https://github.com/jackersson/gstreamer-python.git@{tag_name}#egg=gstreamer-python

--- a/build-3rd-party.sh
+++ b/build-3rd-party.sh
@@ -1,2 +1,5 @@
 cd gstreamer/3rd_party
+
+export GST_PREFIX=${GST_PREFIX:-$(dirname $(dirname $(which python)))} 
+
 ./build.sh

--- a/build-gst-python.sh
+++ b/build-gst-python.sh
@@ -3,12 +3,11 @@
 # Run current script to override Gstreamer related Scripts
 
 LIBPYTHONPATH=""
-PYTHON=${PYTHON:-/usr/bin/python3}
+PYTHON=${PYTHON:-$(which python3)}
 GST_VERSION=${GST_VERSION:-$(gst-launch-1.0 --version | grep version | tr -s ' ' '\n' | tail -1 | $PYTHON -c "import sys; print('.'.join(next(sys.stdin).strip().split('.')[:2]))")}
 
 # Ensure pygst to be installed in current environment
-LIBPYTHON=$($PYTHON -c 'from distutils import sysconfig; print(sysconfig.get_config_var("LDLIBRARY"))')
-LIBPYTHONPATH=$(dirname $(ldconfig -p | grep -w $LIBPYTHON | head -1 | tr ' ' '\n' | grep /))
+LIBPYTHONPATH=$($PYTHON -c 'from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')
 
 GST_PREFIX=${GST_PREFIX:-$(dirname $(dirname $(which python)))} 
 

--- a/build-gst-python.sh
+++ b/build-gst-python.sh
@@ -28,10 +28,13 @@ cd gst-python
 export PYTHON=$PYTHON
 git checkout $GST_VERSION
 
-./autogen.sh --disable-gtk-doc --noconfigure
-./configure --with-libpython-dir=$LIBPYTHONPATH --prefix $GST_PREFIX
-make
-make install
+#./autogen.sh --disable-gtk-doc --noconfigure
+#./configure --with-libpython-dir=$LIBPYTHONPATH --prefix $GST_PREFIX
+#make
+#make install
+meson --prefix=/usr -Dbuildtype=release build
+#ninja -C build
+ninja -C build install
 
 cd ../..
 

--- a/build-gst-python.sh
+++ b/build-gst-python.sh
@@ -32,10 +32,11 @@ cd gst-python
 export PYTHON=$PYTHON
 git checkout $GST_VERSION
 
-# py >= 3.8 && meson >= 0.53, apply patch
+# py >= 3.8 && meson >= 0.53 && gstreamer < 1.19, apply patch
 TEST_PYVER=$($PYTHON -c "from packaging.version import parse; ans = 1 if parse('$PYTHON_VERSION') >= parse('3.8.0') else 0; print(ans)")
 TEST_MESONVER=$($PYTHON -c "from packaging.version import parse; ans = 1 if parse('$MESON_VERSION') >= parse('0.53.0') else 0; print(ans)")
-if [ 1 -eq $TEST_PYVER -a 1 -eq $TEST_MESONVER ] ; then 
+TEST_GSTVER=$($PYTHON -c "from packaging.version import parse; ans = 1 if parse('$GST_VERSION') < parse('1.19') else 0; print(ans)")
+if [ 1 -eq $TEST_PYVER -a 1 -eq $TEST_MESONVER -a 1 -eq $TEST_GSTVER ] ; then
     sed -i 's|python.dependency(required : true)|python.dependency(embed:true, required : true)|g' meson.build
     sed -i "s|meson_version : '.*',|meson_version : '>= 0.53.0',|g" meson.build
 fi

--- a/build-gst-python.sh
+++ b/build-gst-python.sh
@@ -4,7 +4,7 @@
 
 LIBPYTHONPATH=""
 PYTHON=${PYTHON:-/usr/bin/python3}
-GST_VERSION=${GST_VERSION:-$(gst-launch-1.0 --version | grep version | tr -s ' ' '\n' | tail -1)}
+GST_VERSION=${GST_VERSION:-$(gst-launch-1.0 --version | grep version | tr -s ' ' '\n' | tail -1 | $PYTHON -c "import sys; print('.'.join(next(sys.stdin).strip().split('.')[:2]))")}
 
 # Ensure pygst to be installed in current environment
 LIBPYTHON=$($PYTHON -c 'from distutils import sysconfig; print(sysconfig.get_config_var("LDLIBRARY"))')
@@ -32,7 +32,7 @@ git checkout $GST_VERSION
 #./configure --with-libpython-dir=$LIBPYTHONPATH --prefix $GST_PREFIX
 #make
 #make install
-meson --prefix=/usr -Dbuildtype=release build
+meson --prefix=$GST_PREFIX --libdir=$GST_PREFIX/lib -Dpython=$PYTHON -Dlibpython-dir=$LIBPYTHONPATH -Dbuildtype=release build
 #ninja -C build
 ninja -C build install
 

--- a/gstreamer/3rd_party/build.sh
+++ b/gstreamer/3rd_party/build.sh
@@ -10,6 +10,6 @@ if [[ -n "$GST_PREFIX" ]]; then
     BUILD_OPTS="${BUILD_OPTS} --prefix ${GST_PREFIX} --libdir=${GST_PREFIX}/lib"
 fi
 echo $BUILD_OPTS
-meson setup --wipe $BUILD_OPTS build
+meson setup $BUILD_OPTS build
 #ninja -C build
 ninja -C build install

--- a/gstreamer/3rd_party/build.sh
+++ b/gstreamer/3rd_party/build.sh
@@ -3,5 +3,8 @@ ROOT=$PWD
 echo "PWD: $PWD"
 
 # Gstreamer
-cd gstreamer
-./build.sh
+#cd gstreamer
+#./build.sh
+meson build
+#ninja -C build
+ninja -C build install

--- a/gstreamer/3rd_party/build.sh
+++ b/gstreamer/3rd_party/build.sh
@@ -5,6 +5,11 @@ echo "PWD: $PWD"
 # Gstreamer
 #cd gstreamer
 #./build.sh
-meson build
+BUILD_OPTS=""
+if [[ -n "$GST_PREFIX" ]]; then
+    BUILD_OPTS="${BUILD_OPTS} --prefix ${GST_PREFIX} --libdir=${GST_PREFIX}/lib"
+fi
+echo $BUILD_OPTS
+meson setup --wipe $BUILD_OPTS build
 #ninja -C build
 ninja -C build install

--- a/gstreamer/3rd_party/gstreamer/CMakeLists.txt
+++ b/gstreamer/3rd_party/gstreamer/CMakeLists.txt
@@ -25,3 +25,5 @@ message("CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
 set_target_properties(gst_objects_info_meta
                       PROPERTIES COMPILE_FLAGS ${CMAKE_C_FLAGS}
                                  LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
+
+install(TARGETS gst_objects_info_meta DESTINATION lib)

--- a/gstreamer/3rd_party/gstreamer/meson.build
+++ b/gstreamer/3rd_party/gstreamer/meson.build
@@ -1,0 +1,33 @@
+plugin_c_args = ['-DHAVE_CONFIG_H']
+
+cdata = configuration_data()
+cdata.set_quoted('PACKAGE_VERSION', gst_version)
+cdata.set_quoted('PACKAGE', 'gst-itt4rt-plugin')
+# Gstreamer license list: https://gitlab.freedesktop.org/gstreamer/gstreamer/blob/1.16.0/gst/gstplugin.c
+# BSD or MIT/X11
+cdata.set_quoted('GST_LICENSE', 'Proprietary')
+cdata.set_quoted('GST_API_VERSION', api_version)
+cdata.set_quoted('GST_PACKAGE_NAME', 'GStreamer template Plug-ins')
+cdata.set_quoted('GST_PACKAGE_ORIGIN', 'https://gstreamer.freedesktop.org')
+configure_file(output : 'config.h', configuration : cdata)
+
+#gstaudio_dep = dependency('gstreamer-audio-1.0',
+#    fallback: ['gst-plugins-base', 'audio_dep'])
+
+#gstrtp_dep = dependency('gstreamer-rtp-1.0')
+
+
+# Viewport Glib metadata dynamic library
+viewport_meta_sources = [
+  'gst_objects_info_meta.c'
+  ]
+
+# viewport meta
+# create gst_viewport_meta.dll or libgst_viewport_meta.so
+gst_objects_info_meta = library('gst_objects_info_meta',
+  viewport_meta_sources,
+  c_args: plugin_c_args,
+  dependencies : [gst_dep],
+  install : true,
+  install_dir : get_option('libdir'),
+)

--- a/gstreamer/3rd_party/gstreamer/meson.build
+++ b/gstreamer/3rd_party/gstreamer/meson.build
@@ -29,5 +29,5 @@ gst_objects_info_meta = library('gst_objects_info_meta',
   c_args: plugin_c_args,
   dependencies : [gst_dep],
   install : true,
-  install_dir : join_paths(get_option('libdir'), 'gstreamer-1.0'),
+  install_dir : plugins_install_dir,
 )

--- a/gstreamer/3rd_party/gstreamer/meson.build
+++ b/gstreamer/3rd_party/gstreamer/meson.build
@@ -29,5 +29,5 @@ gst_objects_info_meta = library('gst_objects_info_meta',
   c_args: plugin_c_args,
   dependencies : [gst_dep],
   install : true,
-  install_dir : get_option('libdir'),
+  install_dir : join_paths(get_option('libdir'), 'gstreamer-1.0'),
 )

--- a/gstreamer/3rd_party/meson.build
+++ b/gstreamer/3rd_party/meson.build
@@ -1,0 +1,14 @@
+project('gst-rtp-viewport-metadata', 'c', version : '1.0.0.1', license : 'Proprietary')
+
+plugins_install_dir = join_paths(get_option('libdir'), 'gstreamer-1.0')
+
+cc = meson.get_compiler('c')
+
+gst_version = meson.project_version()
+
+api_version = '1.0'
+
+gst_dep = dependency('gstreamer-1.0',
+    fallback : ['gstreamer', 'gst_dep'])
+
+subdir('gstreamer')

--- a/gstreamer/gst_hacks.py
+++ b/gstreamer/gst_hacks.py
@@ -5,7 +5,7 @@ import os
 from ctypes import *
 from typing import Tuple
 from contextlib import contextmanager
-
+import platform
 import gi
 gi.require_version('Gst', '1.0')
 from gi.repository import Gst  # noqa:F401,F402
@@ -24,8 +24,13 @@ class _GstMapInfo(Structure):
 
 
 _GST_MAP_INFO_POINTER = POINTER(_GstMapInfo)
-
-_libgst = CDLL(os.getenv("LIB_GSTREAMER_PATH", "libgstreamer-1.0.so.0"))
+# we need to check the OS
+# "libgstreamer-1.0.dylib"
+if platform.system() == 'Darwin':
+    _libgst = CDLL(os.getenv("LIB_GSTREAMER_PATH", "libgstreamer-1.0.dylib"))
+else:
+    _libgst = CDLL(os.getenv("LIB_GSTREAMER_PATH", "libgstreamer-1.0.so.0"))
+    
 _libgst.gst_buffer_map.argtypes = [c_void_p, _GST_MAP_INFO_POINTER, c_int]
 _libgst.gst_buffer_map.restype = c_int
 

--- a/gstreamer/gst_objects_info_meta.py
+++ b/gstreamer/gst_objects_info_meta.py
@@ -24,8 +24,9 @@ class GstObjectInfoArray(Structure):
 
 GstObjectInfoArrayPtr = POINTER(GstObjectInfoArray)
 
-cwd = os.path.dirname(os.path.abspath(__file__))
-libc = CDLL(os.path.join(cwd, "3rd_party/gstreamer/build/libgst_objects_info_meta.so"))
+#cwd = os.path.dirname(os.path.abspath(__file__))
+#libc = CDLL(os.path.join(cwd, "3rd_party/gstreamer/build/libgst_objects_info_meta.so"))
+libc = CDLL("libgst_objects_info_meta.so")
 
 libc.gst_buffer_add_objects_info_meta.argtypes = [c_void_p, GstObjectInfoArrayPtr]
 libc.gst_buffer_add_objects_info_meta.restype = c_void_p

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ class build_py(_build_py):
                 print("Not found ", bash_file)
 
         cwd = os.path.dirname(os.path.abspath(__file__))
-        #if not bool(self.skip_gst_python):
-        #    _run_bash_file(os.path.join(cwd, 'build-gst-python.sh'))
+        if not bool(self.skip_gst_python):
+           _run_bash_file(os.path.join(cwd, 'build-gst-python.sh'))
         _run_bash_file(os.path.join(cwd, 'build-3rd-party.sh'))
 
         _build_py.run(self)

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ class build_py(_build_py):
                 print("Not found ", bash_file)
 
         cwd = os.path.dirname(os.path.abspath(__file__))
-        if not bool(self.skip_gst_python):
-            _run_bash_file(os.path.join(cwd, 'build-gst-python.sh'))
+        #if not bool(self.skip_gst_python):
+        #    _run_bash_file(os.path.join(cwd, 'build-gst-python.sh'))
         _run_bash_file(os.path.join(cwd, 'build-3rd-party.sh'))
 
         _build_py.run(self)


### PR DESCRIPTION
+ auto detect and Install to virtual env's corresponding interpreter's libdir
  - the old way uses system python's interpreter & libs thus cause some problems
+ work around gst-python's work-around for py3.8
  - otherwise meson will create faulty linking flags
+ add more info to README.md